### PR TITLE
Fix examples for a couple commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ options:
 #### Example
 
 ```
-$ ./octoprint-venv-tool export-plugins ~/oprint plugins.json
+$ ./octoprint-venv-tool export-plugins --output plugins.json ~/oprint
 ```
 
 ### `install-plugins`
@@ -96,7 +96,7 @@ options:
 #### Example
 
 ```
-$ ./octoprint-venv-tool install-plugins ~/oprint plugins.json
+$ ./octoprint-venv-tool install-plugins plugins.json ~/oprint
 ```
 
 ### `create-venv`


### PR DESCRIPTION
I just tried running the example for export-plugins as given, and it failed:

```
usage: octoprint-venv-tool [-h] [--verbose] {export-plugins,install-plugins,create-venv,recreate-venv} ...
octoprint-venv-tool: error: unrecognized arguments: plugins.json
```

Compared with the documented arguments and looks like the example just needed a little fix; also noticed an issue with the install-plugins example and fixed that, but the rest seem fine.