### PR TITLE
Remove trailing slashes on venv paths

### DIFF
--- a/octoprint-venv-tool
+++ b/octoprint-venv-tool
@@ -325,6 +325,7 @@ if __name__ == "__main__":
     if params[0].endswith("python"):
         params = params[1:]
     args = parser.parse_args(params[1:])
+    args.venv = os.path.normpath(args.venv)
 
     subcommand = args.subcommand
     try:


### PR DESCRIPTION
When passing the venv path with trailing slashes (such as when using tab autocomplete) to the script

`./octoprint-venv-tool recreate-venv ./oprint/`

This will result in an error as the backup function appends .bck to the venv path with the trailing slash

```
Backing up existing venv to ./oprint/.bck...
Error running recreate-venv: Cannot move a directory './oprint/' into itself './oprint/.bck'.
```

I propose using os.path.normpath to remove the trailing slashes in an OS agnostic way. 